### PR TITLE
Harden semantic search and link traversal

### DIFF
--- a/src/joplin/joplin_embeddings.py
+++ b/src/joplin/joplin_embeddings.py
@@ -14,6 +14,7 @@ import json
 import logging
 import os
 import re
+import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable
@@ -158,30 +159,38 @@ class VectorIndex:
 _embedder: Embedder | None = None
 _index: VectorIndex | None = None
 _index_loaded = False
+# Guards the lazy init of the globals above. Once the tool layer offloads the
+# heavy calls to a thread pool, these are touched from more than one thread, so
+# the read-check-assign in each accessor needs to be atomic. RLock so a caller
+# already holding it can re-enter without deadlock.
+_lock = threading.RLock()
 
 
 def get_embedder() -> Embedder:
     """The process-wide embedder, loaded on first use (about 5s)."""
     global _embedder
-    if _embedder is None:
-        _embedder = Embedder()
-    return _embedder
+    with _lock:
+        if _embedder is None:
+            _embedder = Embedder()
+        return _embedder
 
 
 def get_index() -> VectorIndex | None:
     """The cached index, read from disk once. None when never built."""
     global _index, _index_loaded
-    if not _index_loaded:
-        _index = load_index()
-        _index_loaded = True
-    return _index
+    with _lock:
+        if not _index_loaded:
+            _index = load_index()
+            _index_loaded = True
+        return _index
 
 
 def set_index(index: VectorIndex | None) -> None:
     """Install an index as the current one, e.g. straight after a build."""
     global _index, _index_loaded
-    _index = index
-    _index_loaded = True
+    with _lock:
+        _index = index
+        _index_loaded = True
 
 
 def reset_runtime() -> None:
@@ -320,10 +329,26 @@ def build_index(api: Any, embedder: Embedder, previous: VectorIndex | None = Non
 
 
 def save_index(index: VectorIndex, path: Path = INDEX_PATH) -> None:
-    """Persist the index to disk."""
+    """Persist the index to disk.
+
+    Written atomically: each file goes to a temp path and is os.replace()d into
+    place, so a crash or a concurrent reader never sees a half-written file. The
+    npz and its metadata are still two separate files, so load_index validates
+    that the pair is mutually consistent rather than trusting it.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
-    np.savez_compressed(path, matrix=index.matrix, chunk_note=index.chunk_note)
-    META_PATH.write_text(
+
+    tmp_npz = path.with_name(path.name + ".tmp")
+    # Pass a file handle, not the path: numpy appends ".npz" to a path that
+    # lacks it, which would corrupt the temp-file name.
+    with open(tmp_npz, "wb") as handle:
+        np.savez_compressed(
+            handle, matrix=index.matrix, chunk_note=index.chunk_note
+        )
+    os.replace(tmp_npz, path)
+
+    tmp_meta = META_PATH.with_name(META_PATH.name + ".tmp")
+    tmp_meta.write_text(
         json.dumps({
             "chunk_texts": index.chunk_texts,
             "note_ids": index.note_ids,
@@ -333,17 +358,18 @@ def save_index(index: VectorIndex, path: Path = INDEX_PATH) -> None:
         }),
         encoding="utf-8",
     )
+    os.replace(tmp_meta, META_PATH)
 
 
 def load_index(path: Path = INDEX_PATH) -> VectorIndex | None:
-    """Load the index, or None when it has not been built yet."""
+    """Load the index, or None when it has not been built or is inconsistent."""
     if not path.exists() or not META_PATH.exists():
         return None
 
     try:
         arrays = np.load(path)
         meta = json.loads(META_PATH.read_text(encoding="utf-8"))
-        return VectorIndex(
+        index = VectorIndex(
             matrix=arrays["matrix"],
             chunk_note=arrays["chunk_note"],
             chunk_texts=meta["chunk_texts"],
@@ -355,6 +381,26 @@ def load_index(path: Path = INDEX_PATH) -> VectorIndex | None:
     except Exception as exc:  # noqa: BLE001 - a corrupt index should rebuild, not crash
         logger.warning(f"Could not load index, treating as absent: {exc}")
         return None
+
+    # A torn write (new npz + stale meta, each individually valid) would load
+    # an index whose arrays disagree and then IndexError at query time. Reject
+    # the mismatch here so it rebuilds instead.
+    chunk_len = index.matrix.shape[0]
+    if not (chunk_len == len(index.chunk_note) == len(index.chunk_texts)):
+        logger.warning("Index chunk arrays disagree in length; rebuilding.")
+        return None
+    note_len = index.note_count
+    if not (note_len == len(index.note_titles) == len(index.note_parents)
+            == len(index.note_stamps)):
+        logger.warning("Index note arrays disagree in length; rebuilding.")
+        return None
+    if index.chunk_count and (
+        int(index.chunk_note.min()) < 0 or int(index.chunk_note.max()) >= note_len
+    ):
+        logger.warning("Index chunk_note references a missing note; rebuilding.")
+        return None
+
+    return index
 
 
 def _best_chunk_per_note(index: VectorIndex, query: np.ndarray) -> tuple[np.ndarray, np.ndarray]:

--- a/src/joplin/joplin_links.py
+++ b/src/joplin/joplin_links.py
@@ -11,6 +11,7 @@ work on a library that has not changed between two calls in the same session.
 
 import logging
 import re
+import threading
 import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, Iterable
@@ -35,6 +36,11 @@ CACHE_TTL_SECONDS = 300
 DIRECTIONS = ("out", "in", "both")
 MAX_DEPTH = 3
 MAX_LIMIT = 200
+# Cap on nodes whose neighbours get expanded. limit only truncates the output;
+# without this the walk still explores the whole reachable component and, with
+# include_semantic, runs one full similarity search per visited node. Bounding
+# expansions bounds that cost regardless of library size.
+MAX_EXPANSIONS = 500
 
 
 @dataclass
@@ -59,19 +65,32 @@ class LinkGraph:
 
 _cache: LinkGraph | None = None
 _notebook_cache: tuple[float, dict[str, str]] | None = None
+# Serializes cache init/rebuild once the tool layer runs these off-thread, and
+# prevents two callers from each doing a full-graph rebuild at once.
+_lock = threading.RLock()
 
 
 def flatten_notebook_paths(
     notebooks: Iterable[JoplinNotebook],
     prefix: str | None = None,
+    _visited: set[str] | None = None,
 ) -> dict[str, str]:
     """Map each notebook id to its full slash-separated path."""
     paths: dict[str, str] = {}
+    # Joplin enforces a tree, but a malformed API response with a parent cycle
+    # would otherwise recurse until the stack is exhausted. Skip any id already
+    # on the current path.
+    visited = _visited if _visited is not None else set()
 
     for notebook in notebooks:
+        if notebook.id in visited:
+            continue
+        visited.add(notebook.id)
         path = f"{prefix}/{notebook.title}" if prefix else notebook.title
         paths[notebook.id] = path
-        paths.update(flatten_notebook_paths(notebook.children or [], path))
+        paths.update(
+            flatten_notebook_paths(notebook.children or [], path, visited)
+        )
 
     return paths
 
@@ -80,17 +99,18 @@ def get_notebook_paths(api: JoplinAPI) -> dict[str, str]:
     """Notebook id to full path, cached briefly. Notebook trees change rarely."""
     global _notebook_cache
 
-    if _notebook_cache and (time.monotonic() - _notebook_cache[0]) < CACHE_TTL_SECONDS:
-        return _notebook_cache[1]
+    with _lock:
+        if _notebook_cache and (time.monotonic() - _notebook_cache[0]) < CACHE_TTL_SECONDS:
+            return _notebook_cache[1]
 
-    try:
-        paths = flatten_notebook_paths(api.list_notebooks())
-    except Exception as exc:  # noqa: BLE001 - paths are a nicety, not a requirement
-        logger.warning(f"Could not resolve notebook paths: {exc}")
-        return _notebook_cache[1] if _notebook_cache else {}
+        try:
+            paths = flatten_notebook_paths(api.list_notebooks())
+        except Exception as exc:  # noqa: BLE001 - paths are a nicety, not a requirement
+            logger.warning(f"Could not resolve notebook paths: {exc}")
+            return _notebook_cache[1] if _notebook_cache else {}
 
-    _notebook_cache = (time.monotonic(), paths)
-    return paths
+        _notebook_cache = (time.monotonic(), paths)
+        return paths
 
 
 def corpus_fingerprint(api: JoplinAPI) -> str:
@@ -156,22 +176,33 @@ def get_link_graph(api: JoplinAPI, refresh: bool = False) -> LinkGraph:
     """Return the cached graph, rebuilding it when the library has moved on."""
     global _cache
 
-    if refresh or _cache is None:
-        _cache = build_link_graph(api)
-        _cache.fingerprint = corpus_fingerprint(api)
+    with _lock:
+        if refresh or _cache is None:
+            return _rebuild_locked(api)
+
+        expired = (time.monotonic() - _cache.built_at) > CACHE_TTL_SECONDS
+        try:
+            changed = corpus_fingerprint(api) != _cache.fingerprint
+        except Exception as exc:  # noqa: BLE001 - a stale graph beats a failed call
+            logger.warning(f"Could not check for changes, serving cached graph: {exc}")
+            changed = False
+
+        if expired or changed:
+            return _rebuild_locked(api)
+
         return _cache
 
-    expired = (time.monotonic() - _cache.built_at) > CACHE_TTL_SECONDS
-    try:
-        changed = corpus_fingerprint(api) != _cache.fingerprint
-    except Exception as exc:  # noqa: BLE001 - a stale graph beats a failed call
-        logger.warning(f"Could not check for changes, serving cached graph: {exc}")
-        changed = False
 
-    if expired or changed:
-        _cache = build_link_graph(api)
-        _cache.fingerprint = corpus_fingerprint(api)
+def _rebuild_locked(api: JoplinAPI) -> LinkGraph:
+    """Build a graph, fingerprint included, then publish it. Call under _lock.
 
+    The fingerprint is set before the graph is assigned to _cache so no reader
+    can observe a published graph whose fingerprint is still unset.
+    """
+    global _cache
+    graph = build_link_graph(api)
+    graph.fingerprint = corpus_fingerprint(api)
+    _cache = graph
     return _cache
 
 
@@ -239,10 +270,16 @@ def find_neighbours(
     seen = {note_id}
     frontier = [note_id]
     found: list[dict[str, Any]] = []
+    expansions = 0
+    capped = False
 
     for hop in range(1, depth + 1):
         next_frontier: list[str] = []
         for current in frontier:
+            if expansions >= MAX_EXPANSIONS:
+                capped = True
+                break
+            expansions += 1
             relations = _neighbours_of(graph, current, direction)
             scores: dict[str, float] = {}
             if semantic_provider is not None:
@@ -269,9 +306,15 @@ def find_neighbours(
                 if relation == "semantic":
                     entry["score"] = round(scores[neighbour], 4)
                 found.append(entry)
-        if not next_frontier:
+        if capped or not next_frontier:
             break
         frontier = next_frontier
+
+    if capped:
+        logger.info(
+            "find_neighbours hit the %d-expansion cap for %s; results partial",
+            MAX_EXPANSIONS, note_id,
+        )
 
     found.sort(key=lambda item: (item["depth"], item["title"].lower()))
 
@@ -282,6 +325,6 @@ def find_neighbours(
             "notebook": graph.notebooks.get(note_id, ""),
         },
         "total": len(found),
-        "truncated": len(found) > limit,
+        "truncated": capped or len(found) > limit,
         "links": found[:limit],
     }

--- a/src/mcp/joplin_mcp.py
+++ b/src/mcp/joplin_mcp.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Any, Optional
 from datetime import datetime
 from pathlib import Path
 
+import anyio
 from mcp.server.fastmcp import FastMCP
 
 # Add the src directory to the Python path
@@ -120,6 +121,10 @@ def resolve_notebook_id(parent_id: Optional[str], notebook_name: Optional[str]) 
 SEARCH_FIELDS = ["id", "title", "body", "parent_id", "updated_time", "is_todo"]
 SEARCH_SNIPPET_CHARS = 200
 SEARCH_MODES = ("hybrid", "keyword", "semantic")
+# Upper bounds on caller-supplied sizing, so one request can't ask for an
+# unbounded result set or excerpt.
+MAX_SEARCH_LIMIT = 200
+MAX_SNIPPET_CHARS = 2000
 # Fusion needs more candidates per side than it returns, or a note ranked well
 # by one side but just outside the other's cut-off can never be promoted.
 CANDIDATE_MULTIPLIER = 3
@@ -195,6 +200,24 @@ async def search_notes(
     if mode not in SEARCH_MODES:
         return {"error": f"mode must be one of {', '.join(SEARCH_MODES)}"}
 
+    # Clamp caller-supplied knobs. limit feeds limit*CANDIDATE_MULTIPLIER into
+    # the embedding search, and keyword_weight>1 makes (1-weight) negative in
+    # the fusion, so an out-of-range value produces garbage ranking or a heavy
+    # query rather than an error.
+    limit = max(1, min(int(limit), MAX_SEARCH_LIMIT))
+    keyword_weight = max(0.0, min(float(keyword_weight), 1.0))
+    snippet_chars = max(0, min(int(snippet_chars), MAX_SNIPPET_CHARS))
+
+    # Keyword search hits the network and semantic search embeds the query and
+    # multiplies the index matrix; both block. Run off the event loop.
+    return await anyio.to_thread.run_sync(
+        _search_notes_sync, query, limit, mode, keyword_weight, snippet_chars
+    )
+
+
+def _search_notes_sync(
+    query: str, limit: int, mode: str, keyword_weight: float, snippet_chars: int
+) -> Dict[str, Any]:
     try:
         notebook_paths = get_notebook_paths(api)
         notes: list[Dict[str, Any]] = []
@@ -299,6 +322,12 @@ async def build_semantic_index(rebuild: bool = False) -> Dict[str, Any]:
     if not api:
         return {"error": "Joplin API client not initialized"}
 
+    # Embedding every note is seconds of pure CPU; run it off the event loop so
+    # it does not stall every other in-flight request.
+    return await anyio.to_thread.run_sync(_build_semantic_index_sync, rebuild)
+
+
+def _build_semantic_index_sync(rebuild: bool) -> Dict[str, Any]:
     try:
         previous = None if rebuild else get_index()
         index = build_index(api, get_embedder(), previous=previous)
@@ -338,6 +367,19 @@ async def find_similar_notes(
     if not api:
         return {"error": "Joplin API client not initialized"}
 
+    limit = max(1, min(int(limit), MAX_SEARCH_LIMIT))
+    min_score = max(0.0, min(float(min_score), 1.0))
+
+    # The similarity matrix multiply plus per-chunk scan is CPU-bound; keep it
+    # off the event loop.
+    return await anyio.to_thread.run_sync(
+        _find_similar_notes_sync, note_id, limit, min_score
+    )
+
+
+def _find_similar_notes_sync(
+    note_id: str, limit: int, min_score: float
+) -> Dict[str, Any]:
     try:
         index = get_index()
         if index is None or index.chunk_count == 0:
@@ -410,6 +452,25 @@ async def find_linked_notes(
     if not api:
         return {"error": "Joplin API client not initialized"}
 
+    # depth and limit are clamped inside find_neighbours; bound the semantic
+    # fan-out here so include_semantic can't request an oversized similarity
+    # search per visited node.
+    semantic_fanout = max(1, min(int(semantic_fanout), 20))
+    semantic_min_score = max(0.0, min(float(semantic_min_score), 1.0))
+
+    # Building the graph pulls every note body, and include_semantic runs a
+    # similarity search per visited node — both blocking. Run off-thread.
+    return await anyio.to_thread.run_sync(
+        _find_linked_notes_sync,
+        note_id, direction, depth, limit, refresh,
+        include_semantic, semantic_fanout, semantic_min_score,
+    )
+
+
+def _find_linked_notes_sync(
+    note_id: str, direction: str, depth: int, limit: int, refresh: bool,
+    include_semantic: bool, semantic_fanout: int, semantic_min_score: float,
+) -> Dict[str, Any]:
     try:
         graph = get_link_graph(api, refresh=refresh)
         provider = None

--- a/tests/test_joplin_links_hardening.py
+++ b/tests/test_joplin_links_hardening.py
@@ -1,0 +1,69 @@
+"""Guards that keep link traversal bounded and crash-proof.
+
+The BFS must not explore an unbounded subgraph (and, with include_semantic,
+run one similarity search per visited node), and notebook flattening must not
+recurse forever on a malformed parent cycle.
+"""
+
+import unittest
+
+from src.joplin.joplin_api import JoplinNotebook
+from src.joplin.joplin_links import (
+    MAX_EXPANSIONS,
+    LinkGraph,
+    find_neighbours,
+    flatten_notebook_paths,
+)
+
+
+class ExpansionCapTests(unittest.TestCase):
+    def _star(self, children: int) -> LinkGraph:
+        # Root "0" links out to `children` nodes, each of which links onward to
+        # a private leaf — enough frontier at hop 2 to blow past the cap.
+        graph = LinkGraph()
+        graph.titles["0"] = "root"
+        for i in range(1, children + 1):
+            cid = str(i)
+            graph.titles[cid] = f"c{i}"
+            graph.outgoing.setdefault("0", set()).add(cid)
+            graph.incoming.setdefault(cid, set()).add("0")
+            leaf = f"leaf{i}"
+            graph.titles[leaf] = leaf
+            graph.outgoing.setdefault(cid, set()).add(leaf)
+            graph.incoming.setdefault(leaf, set()).add(cid)
+        return graph
+
+    def test_expansion_cap_bounds_semantic_calls(self):
+        graph = self._star(MAX_EXPANSIONS + 100)
+        calls = {"n": 0}
+
+        def provider(current):
+            calls["n"] += 1
+            return {}
+
+        result = find_neighbours(
+            graph, note_id="0", direction="both", depth=3, limit=50,
+            semantic_provider=provider,
+        )
+
+        # One provider call per expanded node, and expansions never exceed the
+        # cap — so the per-node similarity search can't run unbounded.
+        self.assertLessEqual(calls["n"], MAX_EXPANSIONS)
+        self.assertTrue(result["truncated"])
+
+
+class NotebookCycleTests(unittest.TestCase):
+    def test_parent_cycle_does_not_recurse_forever(self):
+        # A malformed tree where a child points back at an ancestor.
+        a = JoplinNotebook(id="a", title="A", children=[])
+        b = JoplinNotebook(id="b", title="B", children=[a])
+        a.children = [b]  # cycle: a -> b -> a
+
+        paths = flatten_notebook_paths([a])
+
+        # Terminates, and each id appears once.
+        self.assertEqual(set(paths), {"a", "b"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The notebook tools, link traversal, and semantic search added in #6 are functionally solid — this follows up with robustness fixes for behaviour under load, bad data, and concurrency. No feature changes; all existing tests still pass, plus a new one.

The changes fall into three groups.

### 1. Bound the work and validate inputs

- **`find_neighbours` could explore an unbounded subgraph.** `limit` only truncated the *output* — the BFS still walked the entire reachable component, and with `include_semantic` it ran one full `similar_notes` search *per visited node*. On a large, densely linked library one `find_linked_notes(depth=3, include_semantic=True)` call is very expensive. Now caps expanded nodes at `MAX_EXPANSIONS` (500) and reports `truncated`.
- **`flatten_notebook_paths` had no cycle guard.** Joplin enforces a tree, but a malformed API response with a parent cycle would recurse until the stack is exhausted. Now tracks visited ids.
- **Numeric tool arguments are clamped** in `search_notes` / `find_similar_notes` / `find_linked_notes`. In particular `keyword_weight > 1` made `(1 - keyword_weight)` negative inside `fuse`, producing nonsensical ranking rather than an error.

### 2. Persist the index safely

- **`save_index` wasn't atomic.** It wrote `index.npz` and its `.meta.json` as two separate steps; a crash or a concurrent read in between could pair a new matrix with stale metadata. Each file now goes to a temp path and is `os.replace`d into place.
- **`load_index` now validates consistency** — the npz and metadata must agree in length, and `chunk_note` must reference a real note — returning `None` (triggering a rebuild) on a mismatch instead of `IndexError`-ing later at query time.

### 3. Keep the event loop free (and make the shared caches thread-safe)

- **The four semantic/link tools did seconds of blocking CPU + network work directly on the asyncio event loop**, stalling every other in-flight request. Each now runs its synchronous body via `anyio.to_thread.run_sync`.
- Because that work now runs on a thread pool, the lazy-init module globals (embedder, index, link/notebook caches) are guarded with locks, and the link graph is built fully (fingerprint included) before it's published, so no reader can observe it half-initialized.

Groups 1 and 2 stand on their own; group 3 (offload + locks) is coupled — the locks matter *because* the work now runs off-thread. Happy to split into separate commits/PRs if you'd prefer to take them independently.

### Testing

Existing suites (`test_joplin_search`, `test_joplin_links`, `test_joplin_embeddings`, `test_joplin_mcp`) plus a new `test_joplin_links_hardening` (expansion cap + notebook cycle) — **66 passed**.

---

*Context, in the interest of transparency: these fixes were found while reviewing a downstream fork that packages this server as a container. They're upstreamed here because they're bugs in this repo's own code, independent of anything fork-specific.*
